### PR TITLE
Stop passing the deprecated `step` argument to `optuna.trial.Trial.should_prune`.

### DIFF
--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -150,7 +150,7 @@ class OptunaSolver(solver.Solver):
             self._study._log_completed_trial(trial, value)
         else:
             trial.report(value, current_step)
-            if trial.should_prune(current_step):
+            if trial.should_prune():
                 message = "Pruned trial#{}: step={}, value={}".format(
                     trial.number, current_step, value
                 )

--- a/kurobako/solver/optuna_multi_objective.py
+++ b/kurobako/solver/optuna_multi_objective.py
@@ -155,7 +155,7 @@ class OptunaSolver(solver.Solver):
             #
             # trial.report(values, current_step)
             #
-            # if trial.should_prune(current_step):
+            # if trial.should_prune():
             #     message = "Pruned trial#{}: step={}, value={}".format(
             #         trial.number, current_step, value
             #     )


### PR DESCRIPTION
This PR resolves the issue that the current `kurobako-py` cannot work with the latest Optuna master.