### PR TITLE
Add `warm_starting_trials` option to `OptunaSolverFactory`

### DIFF
--- a/examples/quadratic_problem.py
+++ b/examples/quadratic_problem.py
@@ -1,4 +1,5 @@
 from typing import List
+from typing import Optional
 
 from kurobako import problem
 
@@ -18,13 +19,18 @@ class QuadraticProblemFactory(problem.ProblemFactory):
 
 
 class QuadraticProblem(problem.Problem):
-    def create_evaluator(self, params: List[float]) -> problem.Evaluator:
+    def create_evaluator(self, params: List[Optional[float]]) -> problem.Evaluator:
         return QuadraticEvaluator(params)
 
 
 class QuadraticEvaluator(problem.Evaluator):
-    def __init__(self, params: List[float]):
-        self._x, self._y = params
+    def __init__(self, params: List[Optional[float]]):
+        x, y = params
+        assert x is not None
+        assert y is not None
+
+        self._x = x
+        self._y = y
         self._current_step = 0
 
     def current_step(self) -> int:

--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -177,7 +177,8 @@ class OptunaSolver(solver.Solver):
             value = values[0]
             trial.report(value, current_step)
 
-            # Note that `current_step == 0` means the trail was evaluated during a warm starting phase.
+            # Note that `current_step == 0` means the trail was
+            # evaluated during a warm starting phase.
             if current_step == 0 or trial.should_prune():
                 message = "Pruned trial#{}: step={}, value={}".format(
                     trial.number, current_step, value


### PR DESCRIPTION
Until the number of trials exceeds the option value, they are evaluated with zero cost (i.e., `step==0`).

Note that setting a value greater than `0`, you need to use a problem that supports warm-staring (i.e., `WarmStartingProblem` introduced by https://github.com/sile/kurobako/pull/36).