### PR TITLE
Add name argument to `OptunaSolverFactory`

### DIFF
--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -17,16 +17,18 @@ class OptunaSolverFactory(solver.SolverFactory):
     def __init__(
         self,
         create_study: Callable[[int], optuna.Study],
+        name: str = "Optuna",
         use_discrete_uniform: bool = False,
         warm_starting_trials: int = 0,
     ):
         self._create_study = create_study
+        self._name = name
         self._use_discrete_uniform = use_discrete_uniform
         self._warm_starting_trials = warm_starting_trials
 
     def specification(self) -> solver.SolverSpec:
         return solver.SolverSpec(
-            name="Optuna",
+            name=self._name,
             attrs={
                 "version": "optuna={}, kurobako-py={}".format(
                     get_distribution("optuna").version, get_distribution("kurobako").version


### PR DESCRIPTION
In the current implementation, samplers configured by python scripts are always named `"Optuna"`. This is confusing when summaries and plots are created afterward. 

I feel it would be more convenient if we could specify the name of the sampler in the same python script where the sampler is configured. 

\* If you do not feel this approach looks reasonable, you can just ignore and close this PR.