### PR TITLE
Make `lupa` an optional dependency.

### DIFF
--- a/kurobako/problem.py
+++ b/kurobako/problem.py
@@ -2,13 +2,20 @@ import abc
 import copy
 import enum
 import json
-from lupa import LuaRuntime
 import numpy as np
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
+
+try:
+    from lupa import LuaRuntime
+
+    _lupa_available = True
+except ImportError:
+    _lupa_available = False
+
 
 Self = Any
 
@@ -149,6 +156,11 @@ class Var(object):
     def is_constraint_satisfied(self, vars: List[Self], vals: List[Optional[float]]) -> bool:
         if self.constraint is None:
             return True
+
+        if not _lupa_available:
+            raise RuntimeError(
+                "Please install `lupa` to handle problems containing conditional search space."
+            )
 
         lua = LuaRuntime()
         for var, val in zip(vars, vals):

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     url="https://github.com/sile/kurobako-py",
     license="MIT",
     packages=find_packages(),
-    install_requires=["lupa", "numpy"],
+    install_requires=["numpy"],
     extras_require={"checking": ["hacking", "mypy", "black"]},
 )


### PR DESCRIPTION
This PR makes `lupa` optional to make it easier to install `kurobako-py`.

## Background

It's known that `lupa` has sometimes trouble to install on Mac OS (https://github.com/scoder/lupa/issues/124), despite the Lua library is, actually, only needed when the search space of a target problem is conditional (conditional search space feature is supported by `kurobako` but it's hardly used).