### PR TITLE
Use optuna.Study.ask/tell instead of BaseStorage.set_trial_values etc.

### DIFF
--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -204,12 +204,3 @@ class OptunaSolver(solver.Solver):
                 self._pruned.put((kurobako_trial_id, trial))
             else:
                 self._waitings.put((kurobako_trial_id, trial))
-
-    def _create_new_trial(self):
-        try:
-            trial_id = self._study._storage.create_new_trial(self._study._study_id)
-        except Exception:
-            # For compatibility.
-            trial_id = self._study._storage.create_new_trial(self._study.study_id)
-
-        return optuna.trial.Trial(self._study, trial_id)

--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -1,5 +1,6 @@
 import optuna
 from pkg_resources import get_distribution
+from pkg_resources import DistributionNotFound
 import queue
 from typing import Callable
 from typing import Dict  # NOQA
@@ -27,11 +28,21 @@ class OptunaSolverFactory(solver.SolverFactory):
         self._warm_starting_trials = warm_starting_trials
 
     def specification(self) -> solver.SolverSpec:
+        try: 
+            optuna_version = get_distribution("optuna").version
+        except DistributionNotFound:
+            optuna_version = "unknown" 
+        
+        try:
+            kurobako_version = get_distribution("kurobako").version
+        except DistributionNotFound:
+            kurobako_version = "unknown"
+
         return solver.SolverSpec(
             name=self._name,
             attrs={
                 "version": "optuna={}, kurobako-py={}".format(
-                    get_distribution("optuna").version, get_distribution("kurobako").version
+                    optuna_version, kurobako_version
                 ),
                 "github": "https://github.com/optuna/optuna",
                 "paper": 'Akiba, Takuya, et al. "Optuna: A next-generation hyperparameter '


### PR DESCRIPTION
## Motivation
`OptunaSolver` currently accesses `self._study._storage.set_trial_values` etc. in `tell()`, which is private. The function `set_trial_values` is changed to `set_trial_state_and_values` in newer versions of Optuna, and those lines are also affected. We propose to use `self._study.tell()` instead of directly accessing `self._study._storage.set_trial_values`, and also make corresponding changes to `ask()`.

## Description
* In `OptunaSolver.ask()`, replace call to `self._create_new_trial()` by `self._study.ask()`.
* In `OptunaSolver.tell()`, replace calls to `self._study.sampler.after_trial()`, `self._study._storage.set_trial_values()` and `self._study._storage.set_trial_state()` by `self._study.tell()`.
* Remove `OptunaSolver._create_new_trial()`, which will be unused.
* (Handle `DistributionNotFound` exception in `OptunaSolverFactory.specification()`, which occurs when kurobako-py is not installed via pip. This was necessary for me to test this change in my local environment.)