### PR TITLE
Fix Study._log_completed_trial call

### DIFF
--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -1,4 +1,7 @@
 import optuna
+from optuna.trial import TrialState
+from optuna.version import __version__ as optuna_ver
+from packaging import version
 from pkg_resources import DistributionNotFound
 from pkg_resources import get_distribution
 import queue
@@ -181,7 +184,17 @@ class OptunaSolver(solver.Solver):
         assert current_step <= self._problem.last_step
         if self._problem.last_step == current_step:
             self._study.tell(trial, values=values)
-            self._study._log_completed_trial(trial, values)
+            if version.parse(optuna_ver) >= version.Version("3.0.0b0"):
+                frozen_trial = optuna.trial.create_trial(
+                    state=TrialState.COMPLETE,
+                    values=values,
+                    params=trial.params,
+                    distributions=trial.distributions,
+                )
+                frozen_trial._number = trial.number
+                self._study._log_completed_trial(frozen_trial)
+            else:
+                self._study._log_completed_trial(trial, values)
         else:
             if len(values) > 1:
                 raise NotImplementedError(

--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -1,5 +1,4 @@
 import optuna
-from optuna.trial import TrialState
 from optuna.version import __version__ as optuna_ver
 from packaging import version
 from pkg_resources import DistributionNotFound
@@ -183,15 +182,8 @@ class OptunaSolver(solver.Solver):
 
         assert current_step <= self._problem.last_step
         if self._problem.last_step == current_step:
-            self._study.tell(trial, values=values)
+            frozen_trial = self._study.tell(trial, values=values)
             if version.parse(optuna_ver) >= version.Version("3.0.0b0"):
-                frozen_trial = optuna.trial.create_trial(
-                    state=TrialState.COMPLETE,
-                    values=values,
-                    params=trial.params,
-                    distributions=trial.distributions,
-                )
-                frozen_trial._number = trial.number
                 self._study._log_completed_trial(frozen_trial)
             else:
                 self._study._log_completed_trial(trial, values)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     url="https://github.com/sile/kurobako-py",
     license="MIT",
     packages=find_packages(),
-    install_requires=["numpy", "packaging"],
+    install_requires=["numpy"],
     extras_require={"checking": ["hacking", "mypy", "black"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     url="https://github.com/sile/kurobako-py",
     license="MIT",
     packages=find_packages(),
-    install_requires=["numpy"],
+    install_requires=["numpy", "packaging"],
     extras_require={"checking": ["hacking", "mypy", "black"]},
 )


### PR DESCRIPTION
I bumped a following exception while using `kurobako-py@master` with `optuna@master`.

```
Traceback (most recent call last):
  File "/home/runner/work/cmaes/cmaes/benchmark/optuna_solver.py", line 153, in <module>
    runner.run()
  File "/opt/hostedtoolcache/Python/3.10.4/x[64](https://github.com/CyberAgentAILab/cmaes/runs/5986187038?check_suite_focus=true#step:13:64)/lib/python3.10/site-packages/kurobako/solver/__init__.py", line 184, in run
    while self._run_once():
  File "/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/kurobako/solver/__init__.py", line 200, in _run_once
    self._handle_tell_call(message)
  File "/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/kurobako/solver/__init__.py", line 240, in _handle_tell_call
    solver.tell(trial)
  File "/opt/hostedtoolcache/Python/3.10.4/x64/lib/python3.10/site-packages/kurobako/solver/optuna.py", line 184, in tell
    self._study._log_completed_trial(trial, values)
TypeError: Study._log_completed_trial() takes 2 positional arguments but 3 were given
```

The parameters of `Study._log_completed_trial()` are changed at Optuna v3.0.0-b0 release. Please see https://github.com/optuna/optuna/commit/6a6b0ab2be211a2b3c13fe34eb083650990f5673 for details.