### PR TITLE
Fix bugs in kurobako/solver/optuna.py

### DIFF
--- a/kurobako/solver/optuna.py
+++ b/kurobako/solver/optuna.py
@@ -171,7 +171,7 @@ class OptunaSolver(solver.Solver):
         if len(values) == 0:
             message = "Unevaluable trial#{}: step={}".format(trial.number, current_step)
             _optuna_logger.info(message)
-            frozen_trial = self._study.tell(trial, state=optuna.trial.TrialState.PRUNED)
+            self._study.tell(trial, state=optuna.trial.TrialState.PRUNED)
             return
 
         assert len(values) == len(self._study.directions)
@@ -199,7 +199,7 @@ class OptunaSolver(solver.Solver):
                     trial.number, current_step, value
                 )
                 _optuna_logger.info(message)
-                frozen_trial = self._study.tell(trial, state=optuna.trial.TrialState.PRUNED)
+                self._study.tell(trial, state=optuna.trial.TrialState.PRUNED)
                 self._pruned.put((kurobako_trial_id, trial))
             else:
                 self._waitings.put((kurobako_trial_id, trial))


### PR DESCRIPTION
Several bugs were present in `kurobako/solver/optuna.py` that resulted in errors when used with nontrivial pruners.

* `trial.last_step` is undefined when `trial` is not a `FrozenTrial`.
* `self._study._log_completed_trial` requries a `FrozenTrial`, but a `Trial` is passed
* Logs for pruning are invisible

These bugs are fixed in this PR.